### PR TITLE
Missing linked test case should be created

### DIFF
--- a/Gherkin2Mtm/Gherkin2MtmApi/Helpers/FeatureHelper.cs
+++ b/Gherkin2Mtm/Gherkin2MtmApi/Helpers/FeatureHelper.cs
@@ -10,7 +10,6 @@ using Gherkin2MtmApi.Models;
 using Gherkin2MtmApi.Utils;
 using Microsoft.TeamFoundation.TestManagement.Client;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using Microsoft.VisualStudio.Services.Common;
 using Field = Microsoft.TeamFoundation.WorkItemTracking.Client.Field;
 using ITestBase = Microsoft.TeamFoundation.TestManagement.Client.ITestBase;
 
@@ -211,6 +210,7 @@ namespace Gherkin2MtmApi.Helpers
                     // This could happen when a test case is deleted from the MTM but exists in the corresponding feature file
                     Logger.Info(ResourceStrings.DECORATION, $"Linked test case, {mtmIdTag.Name}, is not found");
                 }
+                // Need to create a test case when the link is failed
                 SaveChanges(teamProject, background, null, scenarioDefinition, hash, area, tags, fieldsCollection);
             }
         }

--- a/Gherkin2Mtm/Gherkin2MtmApi/Helpers/FeatureHelper.cs
+++ b/Gherkin2Mtm/Gherkin2MtmApi/Helpers/FeatureHelper.cs
@@ -203,6 +203,7 @@ namespace Gherkin2MtmApi.Helpers
                     {
                         testCase.Actions.Clear();
                         SaveChanges(teamProject, background, testCase, scenarioDefinition, hash, area, tags, fieldsCollection);
+                        continue;
                     }
                 }
                 catch (DeniedOrNotExistException)
@@ -210,6 +211,7 @@ namespace Gherkin2MtmApi.Helpers
                     // This could happen when a test case is deleted from the MTM but exists in the corresponding feature file
                     Logger.Info(ResourceStrings.DECORATION, $"Linked test case, {mtmIdTag.Name}, is not found");
                 }
+                SaveChanges(teamProject, background, null, scenarioDefinition, hash, area, tags, fieldsCollection);
             }
         }
 


### PR DESCRIPTION
A test case was not getting created when the linked test case for a scenario is no more existing in the Test Manager. Tested it and found working as expected, that the new test case is getting created.