### PR TITLE
Fixed the scenario outline to sceario conversion issues

### DIFF
--- a/Gherkin2Mtm/Gherkin2MtmApi/Helpers/TestCaseHelper.cs
+++ b/Gherkin2Mtm/Gherkin2MtmApi/Helpers/TestCaseHelper.cs
@@ -20,7 +20,10 @@ namespace Gherkin2MtmApi.Helpers
             var isScenarioOutline = scenarioDefinition is ScenarioOutline;
             AddBackground(background, testCase);
             StepHelper.AddSteps(testCase, scenarioDefinition?.Steps, "", isScenarioOutline);
-            if (!isScenarioOutline) return;
+            if (!isScenarioOutline) {
+                testCase.DefaultTable.Reset();
+                return;
+            }
 
             var scenarioOutline = (ScenarioOutline)scenarioDefinition;
             AddParameters(scenarioOutline, testCase);


### PR DESCRIPTION
The flavor of scenario outlines is not removed after it is converted to a scenario. Due to this, the exported or updated corresponding test still showing the parameter table. The change here ensures that the parameters table is reset no matter what so that, it will be considered as a normal test than a parameterized test.'
This is tested and is found working as expected so this can be merged to the master.